### PR TITLE
Type livescore api as array instead of object

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const matches = await getMatches({
 ## Methods
 For the results of the methods, check the typings [here](https://github.com/ErikMichelson/uefa-api/blob/HEAD/src/api.d.ts).
 
-### `getLivescore(): Livescore`
+### `getLivescore(): Livescore[]`
 Returns the score of currently running matches as well as information about upcoming matches in the next hour as well as
 finished matches in the last hour.
 

--- a/src/helpers/livescore.ts
+++ b/src/helpers/livescore.ts
@@ -8,6 +8,6 @@ import { performApiRequest } from '../utils'
  *
  * @returns A promise that resolves with the current livescore.
  */
-export const getLivescore = (): Promise<Livescore> => {
-  return performApiRequest<Livescore>(apiLivescore, {})
+export const getLivescore = (): Promise<Livescore[]> => {
+  return performApiRequest<Livescore[]>(apiLivescore, {})
 }


### PR DESCRIPTION
Moin, great work!

But as far as I can tell, the Livescore API responds with an array of games. In the README, it is accessed as an array as well!


Reply of `https://match.uefa.com/v5/livescore`:
```json
[
    {
        "hash": "f0d389124da1bc17f662da0cbc7e6cd6",
        "id": "2036187",
        "lineupStatus": "TACTICAL_AVAILABLE",
        "phase": "HALF_TIME_BREAK",
       ...
    },
    {
        "hash": "98355ce75232a126d3ce75fe7261921d",
        "id": "2036188",
        "lineupStatus": "TACTICAL_AVAILABLE",
        "phase": "HALF_TIME_BREAK",
        ...
    }
]
```

PS: The package version in `package-lock.json` wasn't updated to `1.0.1` in a8d8b290